### PR TITLE
Shadowkin

### DIFF
--- a/Resources/Prototypes/SimpleStation14/Entities/Mobs/Player/shadowkin.yml
+++ b/Resources/Prototypes/SimpleStation14/Entities/Mobs/Player/shadowkin.yml
@@ -1,3 +1,13 @@
+- type: damageContainer
+  id: Shadowkin
+  supportedGroups:
+    - Brute
+    - Burn
+    - Toxin
+    - Genetic
+  supportedTypes:
+    - Bloodloss
+
 - type: entity
   save: false
   parent: BaseMobHuman
@@ -22,14 +32,14 @@
   - type: MobThresholds
     thresholds: # Weak
       0: Alive
-      80: Critical
-      160: Dead
+      100: Critical
+      200: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
       48: 0.85
       64: 0.65
   - type: Damageable
-    damageContainer: Biological # Shadowkin
+    damageContainer: Shadowkin # Shadowkin
     damageModifierSet: Shadowkin
   - type: Barotrauma
     damage:
@@ -130,7 +140,7 @@
     netsync: false
     noRot: true
     drawdepth: Mobs
-    scale: 0.85, 0.85 # Small
+    scale: 0.8, 0.8 # Small
     layers:
       - map: ["enum.HumanoidVisualLayers.Chest"]
       - map: ["enum.HumanoidVisualLayers.Head"]


### PR DESCRIPTION
## О чем PR
баф сумеречников (повышение кол. урона для крита и смерти до стандартных)
## Почему
у них нет тех способностей из-за которых их статы понёрили
## Технические детали
новый damageContainer был попыткой убрать "задыхается", говорящее о том, мол вы получаете урон удушением, которого нет
## Медиа

- [ ] Я добавил скриншот/видео, показывающее изменения в игре **или** PR не нуждается в показе
- [ ] Я проверил изменения на предмет багов
