### PR TITLE
Рефактор энергомеча и изменение голосования на режим(нюки будет чуть-чуть меньше мб)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -69,10 +69,10 @@
       - state: inhand-right-blade
         shader: unshaded
   - type: Reflect
-    reflectProb: 0.20
-    spread: 20
-    reflects:
-      - Energy #DeltaV: 20% Energy Reflection but no ballistics.
+#    reflectProb: 0.20
+#    spread: 20
+#    reflects:
+#      - Energy #DeltaV: 20% Energy Reflection but no ballistics.
   - type: IgnitionSource
     temperature: 700
 

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -96,7 +96,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 5 # Stray - Was 15 (20)
+    minPlayers: 10 # Stray - Was 15 (20)
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: AntagSelection

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
@@ -13,6 +13,7 @@
   - !type:OverallPlaytimeRequirement #DeltaV
     time: 7200 #2h
 #  whitelistRequired: true
+  - !type:WhitelistRequirement # Stray - Whitelist requirement
   #requirements:
   #  - !type:DepartmentTimeRequirement
   #    department: Security

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -34,6 +34,7 @@
   name: all-at-once-title
   description: all-at-once-description
   showInVote: true # Stray
+  minPlayers: 20 # Stray
   rules:
     - Nukeops
     - Traitor
@@ -89,6 +90,7 @@
   - shittersafarideluxeedition
   name: greenshift-title
   showInVote: true #4boring4vote
+  maxPlayers: 10 # Stray
   description: greenshift-description
   rules:
   - SpaceTrafficControlFriendlyEventScheduler
@@ -176,6 +178,7 @@
   name: nukeops-title
   description: nukeops-description
   showInVote: true # Stray
+  minPlayers: 10
   rules:
     - Nukeops
     - SubGamemodesRule
@@ -192,7 +195,8 @@
     - revolutionaries
   name: rev-title
   description: rev-description
-  showInVote: false
+  showInVote: true # Stray
+  minPlayers: 15 # Stray
   rules:
     - Revolutionary
     - SubGamemodesRule
@@ -211,7 +215,8 @@
   - zomber
   name: zombie-title
   description: zombie-description
-  showInVote: false
+  showInVote: true # Stray
+  minPlayers: 15 # Stray
   rules:
   - Zombie
   - BasicStationEventScheduler


### PR DESCRIPTION
- Отражение у меча 25% для лазеров и баллистики(как раньше).
- Гриншифт теперь только до 10 игроков в голосовании 
- Нюка теперь только от 10 игроков в голосовании.
- Всё и сразу теперь только от 20 игроков в голосовании.
- Добавлена революция как игровой режим в голосование, от 15 игроков.
- Добавлены зомби как игровой режим в голосование, от 15 игроков.
- Гладиатор(фактически тоже зек) теперь тоже на WLе, как и зек.

> [!CAUTION]
> Режим нюки если меньше чем 10 игроков не стартует и перезапускает раунд два раза, я хз фича это или нет.
>
> ![раунд не стартует и перезапускается:((](https://github.com/user-attachments/assets/123cb9ab-d830-4eb5-b1f6-3de964810fd6)

> Если найдёте способ как сделать так, чтобы при 10 и до 19 было 2 нюкера(командир и агент соответственно), но с 20 3, сделайте пожалуйста, ибо я долбаёб и не нашёл