### PR TITLE
SelfUnremovableClothing добавлен к предмету ClothingHeadCage

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
@@ -100,6 +100,7 @@
   - type: Clothing
     sprite: Nyanotrasen/Clothing/Head/Hats/cage.rsi
   - type: HeadCage
+  - type: SelfUnremovableClothing
 
 - type: entity
   parent: ClothingHeadTinfoil


### PR DESCRIPTION
# SelfUnremovableClothing добавлен к предмету ClothingHeadCage
## О чем PR
SelfUnremovableClothing добавлен к предмету ClothingHeadCage
## Почему
SelfUnremovableClothing добавлен к предмету ClothingHeadCage
## Технические детали
SelfUnremovableClothing добавлен к предмету ClothingHeadCage
## Медиа
[SelfUnremovableClothing добавлен к предмету ClothingHeadCage](https://github.com/user-attachments/assets/a46ec128-288d-4d02-ad6f-5c27301fd5a4) <--- это кликабельно

SelfUnremovableClothing добавлен к предмету ClothingHeadCage
- [x] Я добавил скриншот/видео, показывающее изменения в игре **или** PR не нуждается в показе
- [x] Я проверил изменения на предмет багов
- [x] SelfUnremovableClothing добавлен к предмету ClothingHeadCage
