### PR TITLE
больше РАСУ и продвинутые РСУ не стоят 50к)))00 XD LMAO KEK а стоят 110

### DIFF
--- a/Resources/Prototypes/Stray/Entities/Objects/Tools/RCD.yml
+++ b/Resources/Prototypes/Stray/Entities/Objects/Tools/RCD.yml
@@ -60,7 +60,7 @@
       Steel: 600
       Plastic: 100
   - type: StaticPrice
-    price: 50000
+    price: 110
   - type: UserInterface
     interfaces:
       enum.RcdUiKey.Key:
@@ -108,7 +108,7 @@
       Steel: 600
       Plastic: 100
   - type: StaticPrice
-    price: 50000
+    price: 110
   - type: UserInterface
     interfaces:
       enum.RcdUiKey.Key:


### PR DESCRIPTION
# больше РАСУ и пРСУ не стоят 50к)))00 XD LMAO KEK а стоят 110 кредитов
### О чем PR
о балансе так называемом
### Почему
потому что 50к это пиздец, а раундстартом таких РСУ +- 3, ебало карго представили?
### Технические детали
```
  - type: StaticPrice
    price: 50000 ---> 110
```
### Медиа

- [x] PR не нуждается в показе(мне лень в игру заходить даже)
- [x] Я проверил изменения на предмет багов
