### PR TITLE
clustergrenadefix

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ClusterGrenadeSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ClusterGrenadeSystem.cs
@@ -127,7 +127,7 @@ public sealed class ClusterGrenadeSystem : EntitySystem
         if (clug.RandomSpread)
             direction = _random.NextVector2().Normalized();
 
-        _gun.ShootProjectile(grenade, direction, Vector2.One.Normalized(), clugUid);
+        _gun.ShootProjectile(grenade, direction, Vector2.One.Normalized());// , clugUid
 
     }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -387,7 +387,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         EntityUid? user = null,
         bool throwItems = false);
 
-    public void ShootProjectile(EntityUid uid, Vector2 direction, Vector2 gunVelocity, EntityUid gunUid, EntityUid? user = null, float speed = 20f)
+    public void ShootProjectile(EntityUid uid, Vector2 direction, Vector2 gunVelocity, EntityUid? gunUid = null, EntityUid? user = null, float speed = 20f)
     {
         var physics = EnsureComp<PhysicsComponent>(uid);
         Physics.SetBodyStatus(uid, physics, BodyStatus.InAir);
@@ -397,9 +397,12 @@ public abstract partial class SharedGunSystem : EntitySystem
         var finalLinear = physics.LinearVelocity + targetMapVelocity - currentMapVelocity;
         Physics.SetLinearVelocity(uid, finalLinear, body: physics);
 
-        var projectile = EnsureComp<ProjectileComponent>(uid);
-        Projectiles.SetShooter(uid, projectile, user ?? gunUid);
-        projectile.Weapon = gunUid;
+        if (gunUid != null)
+        {
+            var projectile = EnsureComp<ProjectileComponent>(uid);
+            Projectiles.SetShooter(uid, projectile, user ?? gunUid.Value);
+            projectile.Weapon = gunUid;
+        }
 
         TransformSystem.SetWorldRotation(uid, direction.ToWorldAngle());
     }

--- a/Resources/Prototypes/Stray/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Stray/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -132,6 +132,9 @@
       damage:
         types:
           Heat: 3
+    - type: IgniteOnCollide
+      fireStacks: 1
+      count: 10
 
 #- type: entity
 #  id: LiquefiedMethane


### PR DESCRIPTION
я пошыныл, наверна
там кароче было плохо всё с кластерными гранатами.
когда граната взрываются, она приписывают себя выстреленным снарядам в качестве того, что ими выстелило, а потом удаляет себя, и снаряды не могут понять что ими выстелило, вот и появляются ошибки, а я сказал гранате чтобы она себя никуда не приписывала. и теперь снаряды знают что ими ничто не выстреливало и не пытаются понять что за Null ими выстрелило